### PR TITLE
Improved $anchor.attr('href') and $anchor.text() comparison

### DIFF
--- a/library.js
+++ b/library.js
@@ -105,7 +105,7 @@ async function process(content, { type, pid, tid, attachments }) {
 
 		// Skip if the anchor has link text, or has text on the same line.
 		let url = $anchor.attr('href');
-		url = decodeURI(url);
+		url = decodeURI(url); 
 		const text = $anchor.text();
 		const hasSiblings = !!anchor.prev || !!anchor.next;
 		if (hasSiblings || url !== text || anchor.parent.name !== 'p') {

--- a/library.js
+++ b/library.js
@@ -105,6 +105,7 @@ async function process(content, { type, pid, tid, attachments }) {
 
 		// Skip if the anchor has link text, or has text on the same line.
 		let url = $anchor.attr('href');
+		url = decodeURI(url);
 		const text = $anchor.text();
 		const hasSiblings = !!anchor.prev || !!anchor.next;
 		if (hasSiblings || url !== text || anchor.parent.name !== 'p') {


### PR DESCRIPTION

Comparing url decoding results with text can avoid discrepancies in address comparison with Unicode characters.

url !== text is true
url2 !== text is false

```javascript
let url = $anchor.attr('href');
// url = 'https://nodebb.org/%EC%95%88%EB%85%95'
let url2 = decodeURI(url);
// url2 = 'https://nodebb.org/안녕'
const text = $anchor.text();
// text = 'https://nodebb.org/안녕'
```

